### PR TITLE
chore: Make opening PRs easier and less steps missed

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,27 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: author
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+    - RatikKapoor
+    - lemohammed
+    - rjb75
+    - MrClean-1
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0
+
+# A list of assignees, overrides reviewers if set
+# assignees: author
+# A number of assignees to add to the pull request
+# Set to 0 to add all of the assignees.
+# Uses numberOfReviewers if unset.
+numberOfAssignees: 1
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it
+skipKeywords:
+    - wip

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,3 @@
-automerge: '**/*'
-
 integration: 'src/Models/**/*'
 
 front-end:

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -2,3 +2,4 @@ feature: ['feature/*', 'feat/*']
 bug: ['fix/*', 'hotfix/*', 'bug/*']
 documentation: ['docs/*', 'doc/*']
 devops: ['chore/*', 'test/*']
+automerge: '**/*'

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,4 @@
+feature: ['feature/*', 'feat/*']
+bug: ['fix/*', 'hotfix/*', 'bug/*']
+documentation: ['docs/*', 'doc/*']
+devops: ['chore/*', 'test/*']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,4 +1,4 @@
-name: 'Pull Request Labeler'
+name: 'Pull Request Labeler and Assigner'
 on: [pull_request]
 
 jobs:
@@ -8,3 +8,10 @@ jobs:
             - uses: actions/labeler@main
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
+            - uses: TimonVS/pr-labeler-action@v3
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    assign:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: kentaro-m/auto-assign-action@v1.1.2


### PR DESCRIPTION
This PR adds functionality to automatically label PRs based on branch name and add assignees and reviewers.

Changelog:
- Created `.github/auto_assign.yml` and auto assignee and reviewer adding
- Created `.github/pr-labeler.yml` to look at PR branch name and add label automatically
- Added action for both DevOps features in `labeler.yml`
- Moved automerge label location to branch detection