### PR TITLE
feat: Added User to redux state on login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,12 +34,12 @@ import app from './Models/firebase';
 import unProtectedRoutes from './app/routing';
 
 const App: React.FC = () => {
-    const [, setUser] = useState<firebase.default.User | undefined | null>();
+    // const [, setUser] = useState<firebase.default.User | undefined | null>();
 
     useEffect(() => {
         const unSubscribe = app.auth().onAuthStateChanged((user) => {
             if (user) {
-                setUser(user);
+                // setUser(user);
                 //Create redux state here
                 unProtectedRoutes.includes(location.pathname) ? (location.href = '/home') : console.log('At home');
             } else {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,12 +38,12 @@ import app from './Models/firebase';
 import unProtectedRoutes from './app/routing';
 
 const App: React.FC = () => {
-    // const user = useSelector(selectUser); NOTE: Enable this if User needs to be accessed within this file
     const dispatch = useDispatch();
 
     useEffect(() => {
         const unSubscribe = app.auth().onAuthStateChanged((user) => {
             if (user) {
+                console.log('Signed in');
                 dispatch(setUser(user)); // Push user to redux
                 unProtectedRoutes.includes(location.pathname) ? (location.href = '/home') : console.log('At home');
             } else {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { Redirect, Route } from 'react-router-dom';
 import { IonApp, IonRouterOutlet } from '@ionic/react';
 import { IonReactRouter } from '@ionic/react-router';
@@ -8,6 +8,10 @@ import Home from './pages/Home';
 import RegisterLanding from './pages/RegisterLanding';
 import RegisterForm from './pages/RegisterForm';
 import PostView from './pages/PostView';
+
+/* Redux for User */
+import { clearUser, setUser } from './features/User/UserStore';
+import { useDispatch } from 'react-redux';
 
 /* Core CSS required for Ionic components to work properly */
 import '@ionic/react/css/core.css';
@@ -34,15 +38,16 @@ import app from './Models/firebase';
 import unProtectedRoutes from './app/routing';
 
 const App: React.FC = () => {
-    // const [, setUser] = useState<firebase.default.User | undefined | null>();
+    // const user = useSelector(selectUser); NOTE: Enable this if User needs to be accessed within this file
+    const dispatch = useDispatch();
 
     useEffect(() => {
         const unSubscribe = app.auth().onAuthStateChanged((user) => {
             if (user) {
-                // setUser(user);
-                //Create redux state here
+                dispatch(setUser(user)); // Push user to redux
                 unProtectedRoutes.includes(location.pathname) ? (location.href = '/home') : console.log('At home');
             } else {
+                dispatch(clearUser()); // Clear user from redux
                 !unProtectedRoutes.includes(location.pathname) ? (location.href = '/login') : console.log('Safe');
             }
         });

--- a/src/app/store.tsx
+++ b/src/app/store.tsx
@@ -1,6 +1,6 @@
 import { configureStore, ThunkAction, Action } from '@reduxjs/toolkit';
 // import counterReducer from '../features/counter/counterSlice';
-import userReducer from '../features/counter/UserStore';
+import userReducer from '../features/User/UserStore';
 
 export const store = configureStore({
     reducer: {

--- a/src/app/store.tsx
+++ b/src/app/store.tsx
@@ -1,11 +1,17 @@
-import { configureStore, ThunkAction, Action } from '@reduxjs/toolkit';
+import {
+    configureStore,
+    ThunkAction,
+    Action,
+    getDefaultMiddleware,
+    createImmutableStateInvariantMiddleware,
+} from '@reduxjs/toolkit';
 // import counterReducer from '../features/counter/counterSlice';
 import userReducer from '../features/User/UserStore';
-
 export const store = configureStore({
     reducer: {
         user: userReducer,
     },
+    middleware: [createImmutableStateInvariantMiddleware({ ignore: ['user'] })],
 });
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/src/app/store.tsx
+++ b/src/app/store.tsx
@@ -1,10 +1,4 @@
-import {
-    configureStore,
-    ThunkAction,
-    Action,
-    getDefaultMiddleware,
-    createImmutableStateInvariantMiddleware,
-} from '@reduxjs/toolkit';
+import { configureStore, ThunkAction, Action, createImmutableStateInvariantMiddleware } from '@reduxjs/toolkit';
 // import counterReducer from '../features/counter/counterSlice';
 import userReducer from '../features/User/UserStore';
 export const store = configureStore({

--- a/src/app/store.tsx
+++ b/src/app/store.tsx
@@ -1,9 +1,10 @@
 import { configureStore, ThunkAction, Action } from '@reduxjs/toolkit';
-import counterReducer from '../features/counter/counterSlice';
+// import counterReducer from '../features/counter/counterSlice';
+import userReducer from '../features/counter/UserStore';
 
 export const store = configureStore({
     reducer: {
-        counter: counterReducer,
+        user: userReducer,
     },
 });
 

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -21,6 +21,10 @@ import { ellipseOutline, homeOutline, logOutOutline } from 'ionicons/icons';
 import User from '../Models/User';
 
 const TitleBar: React.FC = () => {
+    const handleSignOut = () => {
+        User.signOut();
+    };
+
     return (
         <>
             <IonMenu side="start" content-id="main">
@@ -40,7 +44,7 @@ const TitleBar: React.FC = () => {
                                 <IonIcon icon={ellipseOutline} size="small" class="ion-padding"></IonIcon>
                                 <IonLabel>Landing</IonLabel>
                             </IonItem>
-                            <IonItem onClick={() => User.signOut()}>
+                            <IonItem onClick={() => handleSignOut()}>
                                 <IonIcon icon={logOutOutline} size="small" class="ion-padding"></IonIcon>
                                 <IonLabel>Sign Out</IonLabel>
                             </IonItem>

--- a/src/components/WritePost.tsx
+++ b/src/components/WritePost.tsx
@@ -10,7 +10,7 @@ import {
     IonSelectOption,
 } from '@ionic/react';
 import FireStoreDB from '../Models/firestore';
-import app, { Timestamp } from '../Models/firebase';
+import { Timestamp } from '../Models/firebase';
 import { PostDoc } from '../Models/DocTypes';
 import { InputChangeEventDetail } from '@ionic/core';
 import { loadingComponent } from './Loading';

--- a/src/components/WritePost.tsx
+++ b/src/components/WritePost.tsx
@@ -17,6 +17,8 @@ import { loadingComponent } from './Loading';
 import { PostCategory } from '../Models/Enums';
 import { useHistory } from 'react-router';
 import './HomePostView.scss';
+import { useSelector } from 'react-redux';
+import { selectUser } from '../features/User/UserStore';
 
 const WritePost: React.FC = () => {
     const [content, setContent] = useState('');
@@ -25,13 +27,17 @@ const WritePost: React.FC = () => {
     const [loading, setLoading] = useState(false);
     const db = new FireStoreDB();
     const history = useHistory();
+    const user = useSelector(selectUser);
+    // NOTE: Enable this if User needs to be accessed within this file
+    console.log(user);
 
     async function uploadPost() {
         /**
          * @author Mohamad Abdel Rida
          *  Uploads a post
          */
-        const user = app.auth().currentUser;
+        // const user = app.auth().currentUser;
+
         setLoading(true);
 
         if (user) {

--- a/src/features/User/UserStore.tsx
+++ b/src/features/User/UserStore.tsx
@@ -1,9 +1,9 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { AppThunk, RootState } from '../../app/store';
+import { RootState } from '../../app/store';
 import User from '../../Models/User';
 
 interface UserState {
-    user: User | undefined;
+    user: User | firebase.default.User | undefined;
 }
 
 const initialState: UserState = {
@@ -14,7 +14,7 @@ export const slice = createSlice({
     name: 'user',
     initialState,
     reducers: {
-        setUser: (state, action: PayloadAction<User>) => {
+        setUser: (state, action: PayloadAction<User | firebase.default.User>) => {
             state.user = action.payload;
         },
         clearUser: (state) => {
@@ -38,6 +38,6 @@ export const { setUser, clearUser } = slice.actions;
 // The function below is called a selector and allows us to select a value from
 // the state. Selectors can also be defined inline where they're used instead of
 // in the slice file. For example: `useSelector((state: RootState) => state.counter.value)`
-// export const selectCount = (state: RootState): number => state.counter.value;
+export const selectUser = (state: RootState): User | undefined | firebase.default.User => state.user.user;
 
 export default slice.reducer;

--- a/src/features/User/UserStore.tsx
+++ b/src/features/User/UserStore.tsx
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction, getDefaultMiddleware } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import firebase from 'firebase';
 import { RootState } from '../../app/store';
 import User from '../../Models/User';

--- a/src/features/User/UserStore.tsx
+++ b/src/features/User/UserStore.tsx
@@ -1,9 +1,10 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction, getDefaultMiddleware } from '@reduxjs/toolkit';
+import firebase from 'firebase';
 import { RootState } from '../../app/store';
 import User from '../../Models/User';
 
 interface UserState {
-    user: User | firebase.default.User | undefined;
+    user: User | firebase.User | undefined;
 }
 
 const initialState: UserState = {
@@ -14,7 +15,7 @@ export const slice = createSlice({
     name: 'user',
     initialState,
     reducers: {
-        setUser: (state, action: PayloadAction<User | firebase.default.User>) => {
+        setUser: (state, action: PayloadAction<User | firebase.User>) => {
             state.user = action.payload;
         },
         clearUser: (state) => {
@@ -38,6 +39,6 @@ export const { setUser, clearUser } = slice.actions;
 // The function below is called a selector and allows us to select a value from
 // the state. Selectors can also be defined inline where they're used instead of
 // in the slice file. For example: `useSelector((state: RootState) => state.counter.value)`
-export const selectUser = (state: RootState): User | undefined | firebase.default.User => state.user.user;
+export const selectUser = (state: RootState): User | undefined | firebase.User => state.user.user;
 
 export default slice.reducer;

--- a/src/features/counter/Counter.tsx_disabled
+++ b/src/features/counter/Counter.tsx_disabled
@@ -1,3 +1,4 @@
+/* eslint-ignore */
 import { IonButton, IonInput, IonItem, IonList, IonText } from '@ionic/react';
 import React, { ReactElement, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';

--- a/src/features/counter/UserStore.tsx
+++ b/src/features/counter/UserStore.tsx
@@ -1,0 +1,43 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { AppThunk, RootState } from '../../app/store';
+import User from '../../Models/User';
+
+interface UserState {
+    user: User | undefined;
+}
+
+const initialState: UserState = {
+    user: undefined,
+};
+
+export const slice = createSlice({
+    name: 'user',
+    initialState,
+    reducers: {
+        setUser: (state, action: PayloadAction<User>) => {
+            state.user = action.payload;
+        },
+        clearUser: (state) => {
+            state.user = undefined;
+        },
+    },
+});
+
+export const { setUser, clearUser } = slice.actions;
+
+// The function below is called a thunk and allows us to perform async logic. It
+// can be dispatched like a regular action: `dispatch(incrementAsync(10))`. This
+// will call the thunk with the `dispatch` function as the first argument. Async
+// code can then be executed and other actions can be dispatched
+// export const incrementAsync = (amount: number): AppThunk => (dispatch) => {
+//     setTimeout(() => {
+//         dispatch(incrementByAmount(amount));
+//     }, 1000);
+// };
+
+// The function below is called a selector and allows us to select a value from
+// the state. Selectors can also be defined inline where they're used instead of
+// in the slice file. For example: `useSelector((state: RootState) => state.counter.value)`
+// export const selectCount = (state: RootState): number => state.counter.value;
+
+export default slice.reducer;

--- a/src/features/counter/counterSlice.tsx_disabled
+++ b/src/features/counter/counterSlice.tsx_disabled
@@ -1,3 +1,4 @@
+/* eslint-ignore */
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { AppThunk, RootState } from '../../app/store';
 


### PR DESCRIPTION
User will now live in redux state on login. Currently, `state.user` can be set to types `firebase.default.User`, `User`, or `undefined` (signifying that end user is not logged in). This should be refactored in future versions for only `User` after Firebase auth is merged in to that class.

Redux Demo Image:
![image](https://user-images.githubusercontent.com/14501811/109260123-cd7bd800-77ba-11eb-823f-6bf4f109fd0e.png)

Changelog:
- Deleted `counter` from `store.tsx` and added `UserStore`
- Refactored `TitleBar.tsx` to use `handleSignOut` function for better future maintainability
- Disabled old Counter redux demo
- Created `UserStore.tsx` for User redux state with update and clear functions
- Pushed User to redux state from `App.tsx` as soon as user login is detected