### PR TITLE
Fix: Added spellcheck to text boxes

### DIFF
--- a/src/components/CommentCompose.tsx
+++ b/src/components/CommentCompose.tsx
@@ -26,6 +26,7 @@ const CommentCompose: React.FC<{ user: PrimaryUser; postId: string }> = (props) 
                 <IonCardContent>
                     <IonAvatar></IonAvatar>
                     <IonTextarea
+                        spellcheck={true}
                         placeholder="Write a comment..."
                         className="commentText"
                         onIonChange={(e) => setContent(e.detail.value ?? '')}

--- a/src/components/WritePost.tsx
+++ b/src/components/WritePost.tsx
@@ -58,6 +58,7 @@ const WritePost: React.FC = () => {
             <IonItem>
                 <IonLabel>Title</IonLabel>
                 <IonInput
+                    spellcheck={true}
                     type="text"
                     value={title}
                     onIonChange={(e: CustomEvent<InputChangeEventDetail>) => setTitle(e.detail.value ?? '')}
@@ -84,6 +85,7 @@ const WritePost: React.FC = () => {
             <IonItem>
                 <IonLabel>Content</IonLabel>
                 <IonInput
+                    spellcheck={true}
                     type="text"
                     value={content}
                     onIonChange={(e: CustomEvent<InputChangeEventDetail>) => setContent(e.detail.value ?? '')}

--- a/src/pages/PostView.tsx
+++ b/src/pages/PostView.tsx
@@ -90,7 +90,7 @@ const PostView: React.FC = () => {
                             {post ? <IonLabel>{post.category}</IonLabel> : <IonSkeletonText animated />}
                         </IonChip>
                         {post ? (
-                            <IonTextarea auto-grow="true" value={post.content}></IonTextarea>
+                            <IonTextarea spellcheck={true} auto-grow="true" value={post.content}></IonTextarea>
                         ) : (
                             <IonSkeletonText animated />
                         )}


### PR DESCRIPTION
There's now spellcheck on textboxes. See images below:

![Capture](https://user-images.githubusercontent.com/70828477/111104939-629b0280-8517-11eb-8afb-7909e9144c6f.PNG)

![Capture2](https://user-images.githubusercontent.com/70828477/111104943-6595f300-8517-11eb-8bf6-0ad662db893e.PNG)

![Capture3](https://user-images.githubusercontent.com/70828477/111104948-67f84d00-8517-11eb-8d29-a87ff09c89ce.PNG)

Changelog:

- Added spellcheck to existing textboxes in `src/components/WritePost.tsx`, `src/components/CommentCompose.tsx`, and `src/components/PostView.tsx`