### PR TITLE
fix: Fixed the linear typing when writing a post

### DIFF
--- a/src/components/WritePost.tsx
+++ b/src/components/WritePost.tsx
@@ -91,7 +91,7 @@ const WritePost: React.FC = () => {
                     inputMode="text"
                     value={content}
                     onIonChange={(e: CustomEvent<InputChangeEventDetail>) => setContent(e.detail.value ?? '')}
-                ></IonTextarea>
+                />
             </IonItem>
             <IonButton color="danger" onClick={uploadPost}>
                 Upload Post

--- a/src/components/WritePost.tsx
+++ b/src/components/WritePost.tsx
@@ -8,7 +8,7 @@ import {
     IonInput,
     IonSelect,
     IonSelectOption,
-    IonTextarea
+    IonTextarea,
 } from '@ionic/react';
 import { db, Timestamp } from '../Models/firebase';
 import { PostDoc } from '../Models/DocTypes';
@@ -87,8 +87,8 @@ const WritePost: React.FC = () => {
                 <IonLabel>Content</IonLabel>
                 <IonTextarea
                     spellcheck={true}
-                    autoGrow= {true}
-                    inputMode='text'
+                    autoGrow={true}
+                    inputMode="text"
                     value={content}
                     onIonChange={(e: CustomEvent<InputChangeEventDetail>) => setContent(e.detail.value ?? '')}
                 ></IonTextarea>

--- a/src/components/WritePost.tsx
+++ b/src/components/WritePost.tsx
@@ -8,6 +8,7 @@ import {
     IonInput,
     IonSelect,
     IonSelectOption,
+    IonTextarea
 } from '@ionic/react';
 import { db, Timestamp } from '../Models/firebase';
 import { PostDoc } from '../Models/DocTypes';
@@ -84,12 +85,13 @@ const WritePost: React.FC = () => {
             </IonItem>
             <IonItem>
                 <IonLabel>Content</IonLabel>
-                <IonInput
+                <IonTextarea
                     spellcheck={true}
-                    type="text"
+                    autoGrow= {true}
+                    inputMode='text'
                     value={content}
                     onIonChange={(e: CustomEvent<InputChangeEventDetail>) => setContent(e.detail.value ?? '')}
-                ></IonInput>
+                ></IonTextarea>
             </IonItem>
             <IonButton color="danger" onClick={uploadPost}>
                 Upload Post


### PR DESCRIPTION
The post content will now shift to a new line at the end of the page, opposed to continuously typing in a straight line.

Changelog:
- In `WritePost.tsx`, changed `IonInput` to `IonTextArea`.