### PR TITLE
fix: post fields now clear on submit

### DIFF
--- a/src/components/WritePost.tsx
+++ b/src/components/WritePost.tsx
@@ -53,9 +53,9 @@ const WritePost: React.FC = () => {
             setLoading(false);
             history.push('/home');
 
-            setContent('')
-            setTitle('')
-            setPostCategory(PostCategory.Discussion)
+            setContent('');
+            setTitle('');
+            setPostCategory(PostCategory.Discussion);
         }
     }
     return loading ? (

--- a/src/components/WritePost.tsx
+++ b/src/components/WritePost.tsx
@@ -52,6 +52,10 @@ const WritePost: React.FC = () => {
             });
             setLoading(false);
             history.push('/home');
+
+            setContent('')
+            setTitle('')
+            setPostCategory(PostCategory.Discussion)
         }
     }
     return loading ? (


### PR DESCRIPTION
Fixes the issue where posts fields would not clear when submitted.

Changelog:
-Reset `content`, `title` and `postCategory` states back to default on submit.

Closes issue #95. 